### PR TITLE
Render required modules on top of each module page

### DIFF
--- a/src/main/webapp/css/docs.css
+++ b/src/main/webapp/css/docs.css
@@ -53,6 +53,12 @@ a.workshop:active,
   margin-bottom: 30px;
 }
 
+div.module-prerequisites {
+  background-color: #fffbdd;
+  padding: 20px 40px 10px;
+  border: 1px solid #ecdb56;
+}
+
 /* ------------------------------------------------------------
 Image: "Spin" https://www.flickr.com/photos/eflon/3655695161/
 Author: eflon https://www.flickr.com/photos/eflon/

--- a/src/main/webapp/header.html
+++ b/src/main/webapp/header.html
@@ -75,6 +75,17 @@
             if(match = modulePattern.exec(route)) {
                 var workshop = match[1];
                 var module = match[2];
+
+                // append required modules info
+                if (modules[module] !== null && modules[module].requires.length > 0) {
+                    var prereqModules = $("<div/>").addClass("module-prerequisites").html("These modules are required before starting with the current module:");
+                    var list = $("<ul/>")
+                    prereqModules.append(list);
+                    $.each(modules[module].requires, function(i, prereqModule) {
+                        list.append("<li><a href='" + "#/workshop/" + workshop + "/module/" + prereqModule + "'>" + modules[prereqModule].name + "</a></li>");
+                  });
+                }
+
                 $.get("/api/workshops/" + workshop + "/env/" + module, function(env){
                     var path = module.replace("_", "/");
                     var url = config['contentUrl'] + "/" + path + ".adoc";
@@ -85,7 +96,8 @@
                             'imagesdir=' + config['contentUrl'] + "/images"
                         ];
                         var html = asciidoctor.convert(tmpl.render(env.env), {attributes: options});
-                        content.html(html);
+                        content.html(prereqModules);
+                        content.append($('<div/>').html(html));
                         content.append('<hr/><a href="#/workshop/' + workshop + '">Back</a>');
                     });
                 });

--- a/src/main/webapp/header.html
+++ b/src/main/webapp/header.html
@@ -75,12 +75,13 @@
             if(match = modulePattern.exec(route)) {
                 var workshop = match[1];
                 var module = match[2];
+                var prereqs = $("<div/>");
 
                 // append required modules info
                 if (modules[module] !== null && modules[module].requires.length > 0) {
-                    var prereqModules = $("<div/>").addClass("module-prerequisites").html("These modules are required before starting with the current module:");
+                    prereqs.addClass("module-prerequisites").html("These modules are required before starting with the current module:");
                     var list = $("<ul/>")
-                    prereqModules.append(list);
+                    prereqs.append(list);
                     $.each(modules[module].requires, function(i, prereqModule) {
                         list.append("<li><a href='" + "#/workshop/" + workshop + "/module/" + prereqModule + "'>" + modules[prereqModule].name + "</a></li>");
                   });
@@ -96,7 +97,7 @@
                             'imagesdir=' + config['contentUrl'] + "/images"
                         ];
                         var html = asciidoctor.convert(tmpl.render(env.env), {attributes: options});
-                        content.html(prereqModules);
+                        content.html(prereqs);
                         content.append($('<div/>').html(html));
                         content.append('<hr/><a href="#/workshop/' + workshop + '">Back</a>');
                     });


### PR DESCRIPTION
On top of the module page, list of required modules is displayed to notify users in case (when!) they jump back and forth between modules. The list is extracted from the module configuration.

<img width="932" src="https://cloud.githubusercontent.com/assets/1174934/22741787/b00e24c8-ee14-11e6-9a96-f429f13e1ca4.png">
