### PR TITLE
Error when using incorrect value

### DIFF
--- a/src/main/java/org/openshift/evg/workshopper/workshops/WorkshopProvider.java
+++ b/src/main/java/org/openshift/evg/workshopper/workshops/WorkshopProvider.java
@@ -60,8 +60,12 @@ public class WorkshopProvider {
         	
             Request request = new Request.Builder().url(this.config.getWorkshopsListUrl()).build();
             Response response = this.client.newCall(request).execute();
-            List workshops = this.yaml.loadAs(response.body().byteStream(), List.class);
-            load(workshops);
+            try {
+                List workshops = this.yaml.loadAs(response.body().byteStream(), List.class);
+                load(workshops);
+            }catch(ClassCastException e){
+                LoggerFactory.getLogger(getClass()).error("The provided URL '{}' did not return a List of Workshops", this.config.getWorkshopsListUrl());
+            }
         } else if(this.config.getWorkshopsUrl() != null) {
             List workshops = Arrays.asList(this.config.getWorkshopsUrl().split(","));
             load(workshops);


### PR DESCRIPTION
Fixed a bug where if you specify pass WORKSHOPS_LIST_URL without an actual List gets an error