### PR TITLE
Add support for hosting at sub URL.

### DIFF
--- a/app/controllers/welcome_controller.rb
+++ b/app/controllers/welcome_controller.rb
@@ -5,7 +5,7 @@ class WelcomeController < ApplicationController
   def index
     if Workshopper::Cache.workshops.keys.length == 1
       id = Workshopper::Cache.workshops.keys.first
-      return redirect_to "/workshop/#{id}/"
+      return redirect_to controller: 'welcome', action: 'workshop', workshop: id
     end
 
     @workshops = Workshopper::Cache.workshops.keys.map do |id|
@@ -20,7 +20,7 @@ class WelcomeController < ApplicationController
   def workshop
     @workshop = Workshopper::Cache.workshops[params[:workshop]]
     lab = @workshop.active_labs.first
-    redirect_to "/workshop/#{params[:workshop]}/lab/#{lab}"
+    redirect_to controller: 'welcome', action: 'lab', workshop: params[:workshop], lab: lab
   end
 
   def lab

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -20,7 +20,7 @@
       <span class="navbar-toggler-icon"></span>
     </button>
     <% if @workshop %>
-      <a class="navbar-brand mb-0 h1" href="/workshop/<%= @workshop.id %>" id="workshopName"><%= @workshop.name %></a>
+      <a class="navbar-brand mb-0 h1" href="<%= url_for(controller: 'welcome', action: 'workshop', workshop: @workshop.id) %>" id="workshopName"><%= @workshop.name %></a>
       <% if @lab %>
         <span class="navbar-text" style="margin-right: 1rem;">|</span>
         <span class="navbar-text"><%= @lab.name %></span>

--- a/app/views/welcome/index.html.erb
+++ b/app/views/welcome/index.html.erb
@@ -1,5 +1,5 @@
 <ul>
   <% @workshops.each do |workshop| %>
-  <li><a href="/workshop/<%= workshop[:id] %>"><%= workshop[:name] %></a></li>
+  <li><a href="<%= url_for(controller: 'welcome', action: 'workshop', workshop: workshop[:id]) %>"><%= workshop[:name] %></a></li>
   <% end %>
 </ul>

--- a/app/views/welcome/lab.html.erb
+++ b/app/views/welcome/lab.html.erb
@@ -18,16 +18,16 @@
               <span><%= i += 1 %>. <%= @workshop.lab(id).name %></span>
             </li>
           <% elsif @completed.include?(@workshop.lab(id).id) %>
-            <a href="/workshop/<%= @workshop.id %>/lab/<%= @workshop.lab(id).id %>" class="list-group-item list-group-item-action list-group-item-success">
+            <a href="<%= url_for(controller: 'welcome', action: 'lab', workshop: @workshop.id, lab: @workshop.lab(id).id) %>" class="list-group-item list-group-item-action list-group-item-success">
               <%= i += 1 %>. <%= @workshop.lab(id).name %>
             </a>
           <% else %>
-            <a href="/workshop/<%= @workshop.id %>/lab/<%= @workshop.lab(id).id %>" class="list-group-item list-group-item-action">
+            <a href="<%= url_for(controller: 'welcome', action: 'lab', workshop: @workshop.id, lab: @workshop.lab(id).id) %>" class="list-group-item list-group-item-action">
               <%= i += 1 %>. <%= @workshop.lab(id).name %>
             </a>
           <% end %>
         <% end %>
-        <a href="/workshop/<%= @workshop.id %>/complete" class="list-group-item list-group-item-action list-group-item-warning">
+        <a href="<%= url_for(controller: 'welcome', action: 'complete', workshop: @workshop.id) %>" class="list-group-item list-group-item-action list-group-item-warning">
           <i class="fa fa-print"></i> All labs in one page
         </a>
         <% if ENV['ISSUES_URL'] || @workshop.issues %>
@@ -53,12 +53,12 @@
         </div>
         <div class="card-footer">
           <% if id > 0 %>
-            <a href="/workshop/<%= @workshop.id %>/lab/<%= @workshop.lab(@workshop.active_labs[id - 1]).id %>" class="btn btn-primary btn-sm pull-left">
+            <a href="<%= url_for(controller: 'welcome', action: 'lab', workshop: @workshop.id, lab: @workshop.lab(@workshop.active_labs[id - 1]).id) %>" class="btn btn-primary btn-sm pull-left">
               <i class="fa fa-arrow-left"></i> <%= @workshop.lab(@workshop.active_labs[id - 1]).name %>
             </a>
           <% end %>
           <% if id < @workshop.active_labs.length - 1 %>
-            <a href="/workshop/<%= @workshop.id %>/lab/<%= @workshop.lab(@workshop.active_labs[id + 1]).id %>" class="btn btn-primary btn-sm pull-right">
+            <a href="<%= url_for(controller: 'welcome', action: 'lab', workshop: @workshop.id, lab: @workshop.lab(@workshop.active_labs[id + 1]).id) %>" class="btn btn-primary btn-sm pull-right">
               <%= @workshop.lab(@workshop.active_labs[id + 1]).name %> <i class="fa fa-arrow-right"></i>
             </a>
           <% end %>

--- a/config.ru
+++ b/config.ru
@@ -2,4 +2,20 @@
 
 require_relative 'config/environment'
 
+class FixupScriptName
+    def initialize(app)
+        @app = app
+    end
+
+    def call(env)
+        env['SCRIPT_NAME'] = ActionController::Base.config.relative_url_root
+        env['PATH_INFO'].delete_prefix!(env['SCRIPT_NAME'])
+        @app.call(env)
+    end
+end
+
+if ActionController::Base.config.relative_url_root
+    use FixupScriptName
+end
+
 run Rails.application

--- a/lib/workshopper/renderer/adoc.rb
+++ b/lib/workshopper/renderer/adoc.rb
@@ -1,13 +1,20 @@
 require 'asciidoctor'
 
+include Rails.application.routes.url_helpers
+
 module Workshopper
   class Renderer
     class Adoc
 
       def render(workshop, content)
+        imagesdir = url_for(controller: 'welcome', action: 'asset',
+                            workshop: workshop, path: 'images', ext: 'ext',
+                            only_path: true)
+        imagesdir.delete_suffix!('.ext')
+
         content = Asciidoctor::Document.new(content, attributes: {
             'icons' => 'font',
-            'imagesdir' => "/workshop/#{workshop}/asset/images",
+            'imagesdir' => imagesdir,
             'source-highlighter' => 'coderay',
         })
         content.convert


### PR DESCRIPTION
This includes changes to adjust how URLs are generated when performing redirects so that the URLs generated are correct when the application is hosted at a URL. 

For URL generation, the change is to swap from hard coded absolute URL paths, to calculating the URL path from the controller/action specified for the route, which is the recommended practice anyway. This is needed in the redirects in the controllers, but also where generating the URL path for embedding images.

To allow hosting at a sub URL a Rack middleware is also required to fix up the Rack request environment so that the Rails application is able to work when it is mounted at a sub URL. This is needed specifically because Rack is used to wrap Rails and is in addition to setting various Rails environment variables.

To host at a sub URL, one would set the environment variables:

```
    export RAILS_RELATIVE_URL_ROOT=/suburl
    export RAILS_ASSETS_PATH=/suburl/public
```

cc @jorgemoralespou 